### PR TITLE
director: fix mesh switch time

### DIFF
--- a/director/blueprints.py
+++ b/director/blueprints.py
@@ -79,18 +79,21 @@ def update_mesh(mesh_id):
         abort(404)
 
     if 'switch_time' in values:
-        try:
-            switch_time = int(values['switch_time'])
-            switch_time_parsed = datetime.utcfromtimestamp(switch_time)
-        except ValueError:
-            return 'invalid switch time specified', 400
+        if values['switch_time'] is None:
+            switch_time = None
+        else:
+            try:
+                switch_time = int(values['switch_time'])
+                switch_time_parsed = datetime.utcfromtimestamp(switch_time)
+            except ValueError:
+                return 'invalid switch time specified', 400
 
-        now = datetime.utcnow()
+            now = datetime.utcnow()
 
-        force = 'force' in values and values['force'].lower() in ['true', 'yes', '1']
+            force = 'force' in values and values['force'].lower() in ['true', 'yes', '1']
 
-        if not force and (switch_time_parsed - now).total_seconds() < 0:
-            return 'Specified switch time lies in the past. Force to set value.', 400
+            if not force and (switch_time_parsed - now).total_seconds() < 0:
+                return 'Specified switch time lies in the past. Force to set value.', 400
 
         Mesh.set_switch_time(mesh_db_entry.id, switch_time)
 

--- a/director/director/__init__.py
+++ b/director/director/__init__.py
@@ -97,12 +97,11 @@ class Director:
         domain = domain or self.config["default_domain"]
 
         switch_time = Mesh.get_switch_time(mesh_id)
-        if not Mesh.get_switch_time(mesh_id):
+        if switch_time is None:
             if self.config["only_migrate_vpn"] and not self.mesh_is_vpn_only(mesh_id):
                 switch_time = -1
             else:
                 switch_time = self.config["domain_switch_time"]
-                Mesh.set_switch_time(mesh_id, self.config["domain_switch_time"])
 
         try:
             Node.update(response=domain, query_time=datetime.datetime.now(), switch_time=switch_time).where(


### PR DESCRIPTION
The mesh specific switch time seems to be broken. If understood the idea behind it correctly it should only be set up on request. But with the current implementation it is set to the default switch time for each mesh as soon a node sends a requests.

With the current implementation it was also not possible to unset the mesh switch time via the admin interface as only numbers were allowed.